### PR TITLE
Rubocop warning fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,12 @@
 AllCops:
   Include:
-    - Berksfile
-    - Gemfile
-    - Rakefile
-    - Thorfile
-    - Guardfile
+    - '**/Berksfile'
+    - '**/Gemfile'
+    - '**/Rakefile'
+    - '**/Thorfile'
+    - '**/Guardfile'
   Exclude:
-    - vendor/**
+    - 'vendor/**/*'
 
 ClassLength:
   Enabled: false


### PR DESCRIPTION
From https://github.com/redguide/nodejs/blob/master/.rubocop.yml